### PR TITLE
Fix attachment sizes.

### DIFF
--- a/accessor/gitea/accessor.go
+++ b/accessor/gitea/accessor.go
@@ -24,6 +24,7 @@ type IssueAttachment struct {
 	CommentID int64
 	FileName  string
 	Time      int64
+	Size      int64
 }
 
 // IssueCommentType defines the types of issue comment we support

--- a/importer/setup_ticketAttachment_test.go
+++ b/importer/setup_ticketAttachment_test.go
@@ -131,6 +131,7 @@ func expectIssueAttachmentAddition(t *testing.T, ticket *TicketImport, ticketAtt
 			assertEquals(t, issueAttachment.CommentID, ticketAttachment.comment.issueCommentID)
 			assertEquals(t, issueAttachment.FileName, ticketAttachment.filename)
 			assertEquals(t, issueAttachment.Time, ticketAttachment.comment.time)
+			assertEquals(t, issueAttachment.Size, ticketAttachment.size)
 			return ticketAttachment.issueAttachmentID, nil
 		})
 }

--- a/importer/ticketAttachment.go
+++ b/importer/ticketAttachment.go
@@ -42,7 +42,7 @@ func (importer *Importer) importTicketAttachment(issueID int64, tracAttachment *
 		tracDir[0:4], tracDir[4:8], tracDir[8:12],
 		tracFile[0:12])
 
-	giteaAttachment := gitea.IssueAttachment{UUID: uuid, CommentID: commentID, FileName: tracAttachment.FileName, Time: tracAttachment.Time}
+	giteaAttachment := gitea.IssueAttachment{UUID: uuid, CommentID: commentID, FileName: tracAttachment.FileName, Time: tracAttachment.Time, Size: tracAttachment.Size}
 	_, err = importer.giteaAccessor.AddIssueAttachment(issueID, &giteaAttachment, tracPath)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Set attachment sizes correctly.
Create the neccessary folder structure for attachments if it doesn't already exist. Fixes errors on new Gitea instances.
Closes #3