### PR TITLE
Map common languages in code blocks.

### DIFF
--- a/markdown/codeBlock.go
+++ b/markdown/codeBlock.go
@@ -11,6 +11,9 @@ import (
 var singleLineCodeBlockRegexp = regexp.MustCompile(`{{{([^\n]+?)}}}`)
 var multiLineCodeBlockRegexp = regexp.MustCompile(`(?m)^{{{(?s)(.+?)^}}}`)
 var nonCodeBlockRegexp = regexp.MustCompile(`(?m)(?:}}}$|\A)(?s)(.+?)(?:^{{{|\z)`)
+var commitTicketRefRegexp = regexp.MustCompile(`(?m)\x60\x60\x60\n?#!Commit.*\n`)
+var langRegexp = regexp.MustCompile(`(?m)\x60\x60\x60\n?#!(c|c\+\+|ps1|php|py|sh|cpp|pl)\n`)
+var langMap = map[string]string{"c++": "cpp"}
 
 func (converter *DefaultConverter) convertCodeBlocks(in string) string {
 	// convert single line {{{...}}} to `...`
@@ -23,6 +26,22 @@ func (converter *DefaultConverter) convertCodeBlocks(in string) string {
 	out = multiLineCodeBlockRegexp.ReplaceAllStringFunc(out, func(match string) string {
 		text := multiLineCodeBlockRegexp.ReplaceAllString(match, `$1`)
 		return "```" + text + "```"
+	})
+
+	// but remove #!CommitTicketReference repository="" revision=""
+	out = commitTicketRefRegexp.ReplaceAllString(out, "```\n")
+
+	// and fixup some common languages
+	out = langRegexp.ReplaceAllStringFunc(out, func(match string) string {
+		if matches := langRegexp.FindStringSubmatch(match); matches != nil {
+			if lang, found := langMap[matches[1]]; found {
+				return langRegexp.ReplaceAllString(match, "```"+lang+"\n")
+			} else {
+				return langRegexp.ReplaceAllString(match, "```$1\n")
+			}
+		}
+
+		return match
 	})
 
 	return out

--- a/markdown/codeBlock_test.go
+++ b/markdown/codeBlock_test.go
@@ -40,6 +40,73 @@ func TestMultiLineCodeBlock(t *testing.T) {
 			trailingText)
 }
 
+func TestCodeBlockWithCommitTicketReference(t *testing.T) {
+	setUp(t)
+	defer tearDown(t)
+
+	codeLine1 := "#!CommitTicketReference repository=\"\" revision=\"4574\"\n"
+	codeLine2 := "Remove CommitTicketReference\n"
+
+	conversion := converter.WikiConvert(
+		wikiPage,
+		leadingText+"\n"+
+			"{{{"+codeLine1+
+			codeLine2+
+			"}}}\n"+
+			trailingText)
+	assertEquals(t, conversion,
+		leadingText+"\n"+
+			"```\n"+
+			codeLine2+
+			"```\n"+
+			trailingText)
+}
+
+func TestCodeBlockWithLanguage(t *testing.T) {
+	setUp(t)
+	defer tearDown(t)
+
+	codeLine1 := "#!cpp\n"
+	codeLine2 := "This is some C++\n"
+
+	conversion := converter.WikiConvert(
+		wikiPage,
+		leadingText+"\n"+
+			"{{{"+codeLine1+
+			codeLine2+
+			"}}}\n"+
+			trailingText)
+	assertEquals(t, conversion,
+		leadingText+"\n"+
+			"```cpp\n"+
+			codeLine2+
+			"```\n"+
+			trailingText)
+}
+
+func TestCodeBlockWithMappedLanguage(t *testing.T) {
+	setUp(t)
+	defer tearDown(t)
+
+	codeLine1 := "#!c++\n"
+	codeLine2 := "This is some C++\n"
+
+	// NOTE: We also check \n after {{{ here
+	conversion := converter.WikiConvert(
+		wikiPage,
+		leadingText+"\n"+
+			"{{{\n"+codeLine1+
+			codeLine2+
+			"}}}\n"+
+			trailingText)
+	assertEquals(t, conversion,
+		leadingText+"\n"+
+			"```cpp\n"+
+			codeLine2+
+			"```\n"+
+			trailingText)
+}
+
 func TestNoConversionInsideCodeBlock(t *testing.T) {
 	setUp(t)
 	defer tearDown(t)


### PR DESCRIPTION
Remove `#!CommitTicketReference` lines in code blocks.

Closes #6