### PR TITLE
Add revision maps for mapping svn revision references

### DIFF
--- a/importer/revisionMapper.go
+++ b/importer/revisionMapper.go
@@ -1,0 +1,69 @@
+package importer
+
+import (
+	"regexp"
+
+	"github.com/stevejefferson/trac2gitea/log"
+)
+
+var (
+	revisionRangeRegexp = regexp.MustCompile(`(^|[^\w]\s*)(r\d+)-(?:r)?(\d+)`)
+	revisionRegexp      = regexp.MustCompile(`(^|[^\w]\s*)(r\d+)`)
+	changesetRegexp     = regexp.MustCompile(`In \[(\d+)\]changeset:"\d+":`)
+)
+
+func mapRevision(in string, revisionMap map[string]string) string {
+	return revisionRegexp.ReplaceAllStringFunc(in, func(match string) string {
+		svnRef := revisionRegexp.ReplaceAllString(match, `$2`)
+		if gitRef, found := revisionMap[svnRef]; found == true && gitRef != "" {
+			return revisionRegexp.ReplaceAllString(match, `$1`) + gitRef
+		} else {
+			log.Warn("No matching commit for svn revision '%s'", svnRef)
+		}
+		return match
+	})
+}
+
+func mapRevisionRange(in string, revisionMap map[string]string) string {
+	return revisionRangeRegexp.ReplaceAllStringFunc(in, func(match string) string {
+		svnRefStart := revisionRangeRegexp.ReplaceAllString(match, `$2`)
+		svnRefEnd := "r" + revisionRangeRegexp.ReplaceAllString(match, `$3`)
+
+		if gitRefStart, found := revisionMap[svnRefStart]; found == true && gitRefStart != "" {
+			if gitRefEnd, found := revisionMap[svnRefEnd]; found == true && gitRefEnd != "" {
+				return revisionRangeRegexp.ReplaceAllString(match, `$1`) + gitRefStart + ".." + gitRefEnd
+			} else {
+				log.Warn("No matching commit for svn revision '%s'", svnRefEnd)
+			}
+		} else {
+			log.Warn("No matching commit for svn revision '%s'", svnRefStart)
+		}
+
+		return match
+	})
+}
+
+func mapChangeset(in string, revisionMap map[string]string) string {
+	return changesetRegexp.ReplaceAllStringFunc(in, func(match string) string {
+		svnRef := "r" + changesetRegexp.ReplaceAllString(match, `$1`)
+		if gitRef, found := revisionMap[svnRef]; found == true && gitRef != "" {
+			// NOTE: No colon since Gitea won't link it then.
+			return "See " + gitRef
+		} else {
+			log.Warn("No matching commit for svn revision '%s'", svnRef)
+		}
+		return match
+	})
+}
+
+func MapRevisions(in string, revisionMap map[string]string) string {
+	if revisionMap == nil {
+		return in
+	}
+
+	out := mapRevisionRange(in, revisionMap)
+	out = mapRevision(out, revisionMap)
+	out = mapChangeset(out, revisionMap)
+
+	return out
+}

--- a/importer/revisionMapper_test.go
+++ b/importer/revisionMapper_test.go
@@ -1,0 +1,104 @@
+package importer_test
+
+import (
+	"testing"
+
+	"github.com/stevejefferson/trac2gitea/importer"
+)
+
+func TestMapRevisionsNil(t *testing.T) {
+	var revisionMap map[string]string = nil
+	input := "foo"
+	expected := "foo"
+	result := importer.MapRevisions(input, revisionMap)
+
+	if result != expected {
+		t.Errorf("Expected %s but got %s", expected, result)
+	}
+}
+
+func TestMapBasic(t *testing.T) {
+	revisionMap := map[string]string{
+		"r1234": "deadf00d",
+	}
+	input := "Fixed in r1234"
+	expected := "Fixed in deadf00d"
+
+	result := importer.MapRevisions(input, revisionMap)
+
+	if result != expected {
+		t.Errorf("Expected '%s' but got '%s'", expected, result)
+	}
+}
+
+func TestMapBasicAtStart(t *testing.T) {
+	revisionMap := map[string]string{
+		"r1234": "deadf00d",
+	}
+	input := "r1234 fixes the problem"
+	expected := "deadf00d fixes the problem"
+
+	result := importer.MapRevisions(input, revisionMap)
+
+	if result != expected {
+		t.Errorf("Expected '%s' but got '%s'", expected, result)
+	}
+}
+
+func TestMapNotFound(t *testing.T) {
+	revisionMap := map[string]string{
+		"r1234": "deadf00d",
+	}
+	input := "Fixed in r9999"
+	expected := "Fixed in r9999"
+
+	result := importer.MapRevisions(input, revisionMap)
+
+	if result != expected {
+		t.Errorf("Expected '%s' but got '%s'", expected, result)
+	}
+}
+
+func TestMapRange(t *testing.T) {
+	revisionMap := map[string]string{
+		"r1234": "deadf00d",
+		"r4567": "badcafe",
+	}
+	input := "Implemented in r1234-r4567"
+	expected := "Implemented in deadf00d..badcafe"
+
+	result := importer.MapRevisions(input, revisionMap)
+
+	if result != expected {
+		t.Errorf("Expected '%s' but got '%s'", expected, result)
+	}
+}
+
+func TestMapCommitReference(t *testing.T) {
+	revisionMap := map[string]string{
+		"r4485": "deadf00d",
+	}
+	input := `In [4485]changeset:"4485":`
+	expected := `See deadf00d`
+
+	result := importer.MapRevisions(input, revisionMap)
+
+	if result != expected {
+		t.Errorf("Expected '%s' but got '%s'", expected, result)
+	}
+}
+
+func TestMapMergeRange(t *testing.T) {
+	revisionMap := map[string]string{
+		"r4415": "deadf00d",
+		"r4419": "badcafe",
+	}
+	input := "Merged revision(s) r4415-4419 from branches/multi_monitor:"
+	expected := "Merged revision(s) deadf00d..badcafe from branches/multi_monitor:"
+
+	result := importer.MapRevisions(input, revisionMap)
+
+	if result != expected {
+		t.Errorf("Expected '%s' but got '%s'", expected, result)
+	}
+}

--- a/importer/setup_ticket_test.go
+++ b/importer/setup_ticket_test.go
@@ -57,6 +57,7 @@ var (
 	severityMap   map[string]string
 	typeMap       map[string]string
 	versionMap    map[string]string
+	revisionMap   map[string]string
 )
 
 func initMaps() {

--- a/importer/ticketAttachment.go
+++ b/importer/ticketAttachment.go
@@ -13,7 +13,7 @@ import (
 )
 
 // importTicketAttachment imports a single ticket attachment from Trac into Gitea, returns UUID if newly-created attachment or "" if attachment already existed
-func (importer *Importer) importTicketAttachment(issueID int64, tracAttachment *trac.TicketAttachment, userMap map[string]string) (string, error) {
+func (importer *Importer) importTicketAttachment(issueID int64, tracAttachment *trac.TicketAttachment, userMap, revisionMap map[string]string) (string, error) {
 	// convert attachment description into a Gitea issue comment
 	commentText := fmt.Sprintf("**Attachment** %s (%d bytes) added\n\n%s", tracAttachment.FileName, tracAttachment.Size, tracAttachment.Description)
 	tracChange := trac.TicketChange{
@@ -23,7 +23,7 @@ func (importer *Importer) importTicketAttachment(issueID int64, tracAttachment *
 		NewValue:   commentText,
 		Time:       tracAttachment.Time,
 	}
-	commentID, err := importer.importCommentIssueComment(issueID, &tracChange, userMap)
+	commentID, err := importer.importCommentIssueComment(issueID, &tracChange, userMap, revisionMap)
 	if err != nil {
 		return "", err
 	}
@@ -51,11 +51,11 @@ func (importer *Importer) importTicketAttachment(issueID int64, tracAttachment *
 	return uuid, nil
 }
 
-func (importer *Importer) importTicketAttachments(ticketID int64, issueID int64, lastUpdate int64, userMap map[string]string) (int64, error) {
+func (importer *Importer) importTicketAttachments(ticketID int64, issueID int64, lastUpdate int64, userMap, revisionMap map[string]string) (int64, error) {
 	attachmentLastUpdate := lastUpdate
 
 	err := importer.tracAccessor.GetTicketAttachments(ticketID, func(attachment *trac.TicketAttachment) error {
-		uuid, err := importer.importTicketAttachment(issueID, attachment, userMap)
+		uuid, err := importer.importTicketAttachment(issueID, attachment, userMap, revisionMap)
 		if err != nil {
 			return err
 		}

--- a/importer/ticketAttachment_test.go
+++ b/importer/ticketAttachment_test.go
@@ -35,7 +35,7 @@ func TestImportTicketWithAttachments(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportMultipleTicketsWithAttachments(t *testing.T) {
@@ -74,7 +74,7 @@ func TestImportMultipleTicketsWithAttachments(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketWithAttachmentButNoTracUser(t *testing.T) {
@@ -105,7 +105,7 @@ func TestImportTicketWithAttachmentButNoTracUser(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketWithAttachmentButUnmappedTracUser(t *testing.T) {
@@ -136,5 +136,5 @@ func TestImportTicketWithAttachmentButUnmappedTracUser(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }

--- a/importer/ticketChange.go
+++ b/importer/ticketChange.go
@@ -51,13 +51,13 @@ func (importer *Importer) createIssueComment(issueID int64, change *trac.TicketC
 func (importer *Importer) importTicketChange(
 	issueID int64,
 	change *trac.TicketChange,
-	userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap map[string]string) (int64, error) {
+	userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap map[string]string) (int64, error) {
 	var issueCommentID int64
 	var err error
 
 	switch change.ChangeType {
 	case trac.TicketCommentChange:
-		issueCommentID, err = importer.importCommentIssueComment(issueID, change, userMap)
+		issueCommentID, err = importer.importCommentIssueComment(issueID, change, userMap, revisionMap)
 	case trac.TicketComponentChange:
 		issueCommentID, err = importer.importLabelChangeIssueComment(issueID, change, userMap, componentMap)
 	case trac.TicketMilestoneChange:
@@ -90,10 +90,10 @@ func (importer *Importer) importTicketChanges(
 	ticketID int64,
 	issueID int64,
 	lastUpdate int64,
-	userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap map[string]string) (int64, error) {
+	userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap map[string]string) (int64, error) {
 	commentLastUpdate := lastUpdate
 	err := importer.tracAccessor.GetTicketChanges(ticketID, func(change *trac.TicketChange) error {
-		commentID, err := importer.importTicketChange(issueID, change, userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+		commentID, err := importer.importTicketChange(issueID, change, userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 		if err != nil {
 			return err
 		}

--- a/importer/ticketComment.go
+++ b/importer/ticketComment.go
@@ -10,7 +10,7 @@ import (
 )
 
 // importCommentIssueComment imports a Trac ticket comment into Gitea, returns id of created Gitea issue comment or NullID if cannot create comment
-func (importer *Importer) importCommentIssueComment(issueID int64, change *trac.TicketChange, userMap map[string]string) (int64, error) {
+func (importer *Importer) importCommentIssueComment(issueID int64, change *trac.TicketChange, userMap, revisionMap map[string]string) (int64, error) {
 	issueComment, err := importer.createIssueComment(issueID, change, userMap)
 	if err != nil {
 		return gitea.NullID, err
@@ -18,6 +18,7 @@ func (importer *Importer) importCommentIssueComment(issueID int64, change *trac.
 
 	issueComment.CommentType = gitea.CommentIssueCommentType
 	issueComment.Text = importer.markdownConverter.TicketConvert(change.TicketID, change.NewValue)
+	issueComment.Text = MapRevisions(issueComment.Text, revisionMap)
 
 	issueCommentID, err := importer.giteaAccessor.AddIssueComment(issueID, issueComment)
 	if err != nil {

--- a/importer/ticketComment_test.go
+++ b/importer/ticketComment_test.go
@@ -35,7 +35,7 @@ func TestImportTicketWithComments(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportMultipleTicketsWithComments(t *testing.T) {
@@ -74,7 +74,7 @@ func TestImportMultipleTicketsWithComments(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketWithCommentButNoTracUser(t *testing.T) {
@@ -105,7 +105,7 @@ func TestImportTicketWithCommentButNoTracUser(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketWithCommentButUnmappedTracUser(t *testing.T) {
@@ -136,5 +136,5 @@ func TestImportTicketWithCommentButUnmappedTracUser(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }

--- a/importer/ticketLabel_test.go
+++ b/importer/ticketLabel_test.go
@@ -34,7 +34,7 @@ func TestImportTicketComponentAddition(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketComponentAmend(t *testing.T) {
@@ -65,7 +65,7 @@ func TestImportTicketComponentAmend(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketComponentRemoval(t *testing.T) {
@@ -96,7 +96,7 @@ func TestImportTicketComponentRemoval(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketPriorityAddition(t *testing.T) {
@@ -127,7 +127,7 @@ func TestImportTicketPriorityAddition(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketPriorityAmend(t *testing.T) {
@@ -158,7 +158,7 @@ func TestImportTicketPriorityAmend(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketPriorityRemoval(t *testing.T) {
@@ -189,7 +189,7 @@ func TestImportTicketPriorityRemoval(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketResolutionAddition(t *testing.T) {
@@ -220,7 +220,7 @@ func TestImportTicketResolutionAddition(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketResolutionAmend(t *testing.T) {
@@ -251,7 +251,7 @@ func TestImportTicketResolutionAmend(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketResolutionRemoval(t *testing.T) {
@@ -282,7 +282,7 @@ func TestImportTicketResolutionRemoval(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketSeverityAddition(t *testing.T) {
@@ -313,7 +313,7 @@ func TestImportTicketSeverityAddition(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketSeverityAmend(t *testing.T) {
@@ -344,7 +344,7 @@ func TestImportTicketSeverityAmend(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketSeverityRemoval(t *testing.T) {
@@ -375,7 +375,7 @@ func TestImportTicketSeverityRemoval(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketTypeAddition(t *testing.T) {
@@ -406,7 +406,7 @@ func TestImportTicketTypeAddition(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketTypeAmend(t *testing.T) {
@@ -437,7 +437,7 @@ func TestImportTicketTypeAmend(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketTypeRemoval(t *testing.T) {
@@ -468,7 +468,7 @@ func TestImportTicketTypeRemoval(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketVersionAddition(t *testing.T) {
@@ -499,7 +499,7 @@ func TestImportTicketVersionAddition(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketVersionAmend(t *testing.T) {
@@ -530,7 +530,7 @@ func TestImportTicketVersionAmend(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketVersionRemoval(t *testing.T) {
@@ -561,5 +561,5 @@ func TestImportTicketVersionRemoval(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }

--- a/importer/ticketMilestone_test.go
+++ b/importer/ticketMilestone_test.go
@@ -34,5 +34,5 @@ func TestImportTicketMilestone(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }

--- a/importer/ticketOwnership_test.go
+++ b/importer/ticketOwnership_test.go
@@ -34,7 +34,7 @@ func TestImportTicketOwnershipChange(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketOwnershipRemoval(t *testing.T) {
@@ -65,5 +65,5 @@ func TestImportTicketOwnershipRemoval(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }

--- a/importer/ticketStatus_test.go
+++ b/importer/ticketStatus_test.go
@@ -34,7 +34,7 @@ func TestImportTicketClose(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketReopen(t *testing.T) {
@@ -65,5 +65,5 @@ func TestImportTicketReopen(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }

--- a/importer/ticketSummary_test.go
+++ b/importer/ticketSummary_test.go
@@ -34,5 +34,5 @@ func TestImportTicketSummary(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, nil)
 }

--- a/importer/ticket_compound_test.go
+++ b/importer/ticket_compound_test.go
@@ -45,7 +45,7 @@ func TestImportTicketWithAttachmentsAndComments(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportMultipleTicketsWithAttachmentsAndComments(t *testing.T) {
@@ -92,5 +92,5 @@ func TestImportMultipleTicketsWithAttachmentsAndComments(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }

--- a/importer/ticket_test.go
+++ b/importer/ticket_test.go
@@ -33,7 +33,7 @@ func TestImportClosedTicketOnly(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportOpenTicketOnly(t *testing.T) {
@@ -61,7 +61,7 @@ func TestImportOpenTicketOnly(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportMultipleTicketsOnly(t *testing.T) {
@@ -94,7 +94,7 @@ func TestImportMultipleTicketsOnly(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketWithNoTracUser(t *testing.T) {
@@ -122,7 +122,7 @@ func TestImportTicketWithNoTracUser(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }
 
 func TestImportTicketWithUnmappedTracUser(t *testing.T) {
@@ -150,5 +150,5 @@ func TestImportTicketWithUnmappedTracUser(t *testing.T) {
 	// expect all issue counts to be updated
 	expectIssueCountUpdates(t)
 
-	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap)
+	dataImporter.ImportTickets(userMap, componentMap, priorityMap, resolutionMap, severityMap, typeMap, versionMap, revisionMap)
 }

--- a/revisionMap.go
+++ b/revisionMap.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+var revisionRegexp = regexp.MustCompile(`^r\d+`)
+
+// readRevisionMap reads the revision map (SVN revisions -> Git commits map)
+// from the provided file. Returns nil if no file was provided
+func readRevisionMap(mapFile string) (map[string]string, error) {
+	if mapFile == "" {
+		return nil, nil
+	}
+
+	fd, err := os.Open(mapFile)
+	if err != nil {
+		return nil, err
+	}
+
+	defer fd.Close()
+
+	revisionMap := make(map[string]string)
+	scanner := bufio.NewScanner(fd)
+
+	for scanner.Scan() {
+		revisionMapLine := scanner.Text()
+		if revisionMapLine == "" {
+			continue
+		}
+
+		equalsPos := strings.LastIndex(revisionMapLine, "=")
+		if equalsPos == -1 {
+			return nil, fmt.Errorf("badly formatted revision map file %s: found line %s", mapFile, revisionMapLine)
+		}
+
+		gitRef := strings.Trim(revisionMapLine[0:equalsPos], " ")
+		svnRevision := strings.Trim(revisionMapLine[equalsPos+1:], " ")
+		svnRevision = revisionRegexp.FindString(svnRevision)
+
+		if svnRevision != "" {
+			if _, found := revisionMap[svnRevision]; found == true {
+				return nil, fmt.Errorf("Revision map file %s: contains multiple entries for %s", mapFile, svnRevision)
+			}
+			revisionMap[svnRevision] = gitRef
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return revisionMap, nil
+}


### PR DESCRIPTION
...in comments to git commits by using a mapping file extracted from git-notes created by subgit

See #19.